### PR TITLE
differentiate attribute when user provides invalid input

### DIFF
--- a/R/get_wormsid.R
+++ b/R/get_wormsid.R
@@ -109,7 +109,7 @@ get_wormsid <- function(searchterm, searchtype = "scientific", accepted = TRUE, 
           } else {
             wormsid <- NA
             mssg(verbose, "\nReturned 'NA'!\n\n")
-            att <- 'not found'
+            att <- 'invalid user input'
           }
         } else {
           wormsid <- NA


### PR DESCRIPTION
when the user gives an invalid input, when offered the choice for multiple matches, it would be useful to differentiate it from "no match"
